### PR TITLE
Justify text by default

### DIFF
--- a/_layouts/review.html
+++ b/_layouts/review.html
@@ -5,6 +5,9 @@ layout: default
   main.page-content {
     padding-bottom: 0;
   }
+  div.post-content p {
+    text-align: justify; /* helps the reading flow */
+  }
   h1.post-title {
     font-size: 2.2rem;
     line-height: 2.6rem;

--- a/deep-learning/_posts/2017-02-09-batch-norm.md
+++ b/deep-learning/_posts/2017-02-09-batch-norm.md
@@ -12,12 +12,6 @@ cite:
 
 Batch Normalization (BN) is a layer to be inserted in a deep neural network, to accelerate training.[^1]
 
-<style>
-  div.post-content p {
-    text-align: justify; /* helps the reading flow */
-  }
-</style>
-
 # Why use it
 
 We want to reduce _**Internal Covariate Shift**_, the change in the distributions of internal nodes of a deep network during training. It is advantageous for the distribution of a layer input to remain fixed over time. To do so, we will **fix the means and variances of layer inputs**.


### PR DESCRIPTION
Let's remove that ugly `<style>` block from the post body. Text will be justified by default.