### PR TITLE
BUG: Improve self review cross-references.

### DIFF
--- a/deep-learning/_posts/2018-11-23-OBELISK.md
+++ b/deep-learning/_posts/2018-11-23-OBELISK.md
@@ -81,7 +81,7 @@ entire image batches used in FCNs.
 
 ## Data
 
-10 CT scans from the VISCERAL3 dataset[^ref1]. 7 classes.
+10 CT scans from the VISCERAL3 dataset[JimenezDelToro:206:TMI]. 7 classes.
 
 
 # Results
@@ -91,7 +91,8 @@ entire image batches used in FCNs.
 - Compared results to a U-Net architecture with 14 $$3 \times 3 \times 3$$
 convolutional layers and 8-128 channels.
 - Improved convergence.
-- Training using "online hard example mining"[^ref2] improves results.
+- Training using "online hard example mining"[Shrivastava:2016:CompVisPatternRecog]
+improves results.
 - Coordinate transform geometric data augmentation improves results.
 
 ![](/deep-learning/images/OBELISK/Segmentation_result.png)
@@ -143,13 +144,14 @@ U-Net architectures may still be better than using OBELISK.
 
 
 # References
-[^ref1]: Oscar Jimenez-del Toro, Henning Müller, Markus Krenn, Katharina
-Gruenberg, Abdel Aziz Taha, Marianne Winterstein, Ivan Eggel, Antonio
+[JimenezDelToro:206:TMI]: Oscar Jimenez-del-Toro, Henning Müller, Markus Krenn,
+Katharina Gruenberg, Abdel Aziz Taha, Marianne Winterstein, Ivan Eggel, Antonio
 Foncubierta-Rodríguez, Orcun Goksel, András Jakab, et al. Cloud-based
 evaluation of anatomical structure segmentation and landmark detection
 algorithms: Visceral anatomy benchmarks. IEEE transactions on medical imaging,
 35(11):2459–2475, 2016.
 
-[^ref2]: Abhinav Shrivastava, Abhinav Gupta, and Ross Girshick. Training
-region-based object detectors with online hard example mining.In Proceedings of
-the IEEE Conference on Computer Vision and Pattern Recognition, pages 761–769, 2016.
+[Shrivastava:2016:CompVisPatternRecog]: Abhinav Shrivastava, Abhinav Gupta, and
+Ross Girshick. Training region-based object detectors with online hard example
+mining. In Proceedings of the IEEE Conference on Computer Vision and Pattern
+Recognition, pages 761–769, 2016.

--- a/deep-learning/_posts/2018-11-30-NeuroNet.md
+++ b/deep-learning/_posts/2018-11-30-NeuroNet.md
@@ -17,8 +17,8 @@ pdf: "https://openreview.net/pdf?id=Hks1TRisM"
 # Highlights
 
 - NeuroNet is a deep convolutional neural network mimicking multiple popular
-and state-of-the-art brain segmentation tools including FSL[^1], SPM[^2],
-and MALPEM[^3].
+and state-of-the-art brain segmentation tools including FSL[FSL], SPM[SPM],
+and MALPEM[MALPEM].
 - Produces outputs from raw images, avoiding pre-processing steps (e.g. bias
 correction or skull-stripping).
 - Reduced processing time by an order of magnitude compared to running each
@@ -29,7 +29,7 @@ individual software package.
 # Introduction
 
 The disparity of results in brain tissue segmentation in neuroimaging tools
-such as FSL[^1], SPM[^2], and MALPEM[^3] puts neuroscientists before
+such as FSL[FSL], SPM[SPM], and MALPEM[MALPEM] puts neuroscientists before
 the dilemma of which tool to choose.
 
 Authors hypothesize that learning a CNN model from multiple gold-standard
@@ -65,7 +65,7 @@ gold-standard reference.
 ## Data
 
 Trained on $$5000$$ T1-weighted brain MRI scans from the UK Biobank Imaging
-Study[^4] with data augmentation; $$10$$ validation volumes; and
+Study[UKBiobank] with data augmentation; $$10$$ validation volumes; and
 $$713$$ test datasets.
 
 ## Pre-processing
@@ -102,8 +102,7 @@ unclear.
 model does not compare well, so it deserves a more fair comparison.
 
 
-# References
-[^1]: https://fsl.fmrib.ox.ac.uk/fsl/fslwiki
-[^2]: https://www.fil.ion.ucl.ac.uk/spm/
-[^3]: https://biomedia.doc.ic.ac.uk/software/malp-em/
-[^4]: https://www.ukbiobank.ac.uk/
+[FSL]: https://fsl.fmrib.ox.ac.uk/fsl/fslwiki
+[SPM]: https://www.fil.ion.ucl.ac.uk/spm/
+[MALPEM]: https://biomedia.doc.ic.ac.uk/software/malp-em/
+[UKBiobank]: https://www.ukbiobank.ac.uk/

--- a/deep-learning/_posts/2018-12-21-DeepTract.md
+++ b/deep-learning/_posts/2018-12-21-DeepTract.md
@@ -22,7 +22,7 @@ without assuming a specific diffusion mode.
 - Authors propose to use a discrete classification framework, rather than a
 regression framework to allow for probabilistic tracking.
 - Improved performance scores are reported over state-of-the art classical and
-DL methods on the ISMRM 2015 Challenge dataset [^1].
+DL methods on the ISMRM 2015 Challenge dataset [Maier-Hein:2016:biorxiv].
 
 
 # Introduction
@@ -109,8 +109,8 @@ stopping criteria: $$a=3$$, $$b=10$$ and $$c=4.5$$.
 
 ## Data
 
-- ISMRM 2015 Tractography Challenge phantom dataset [^1].
-- Training on (i) ground-truth tractogram; (ii) MITK [^2] tractogram.
+- ISMRM 2015 Tractography Challenge phantom dataset [Maier-Hein:2016:biorxiv].
+- Training on (i) ground-truth tractogram; (ii) MITK [MITK] tractogram.
 - "Ground-truth" whole brain tractography created using Q-ball reconstruction,
 followed by probabilistic streamline tracking using MITK diffusion tool.
 Resulting streamlines were randomly divided into training and validation sets.
@@ -120,7 +120,7 @@ in the training set.
 
 # Results
 
-- Evaluation using the Tractometer [^3] score.
+- Evaluation using the Tractometer [Cote:2013:MIA] score.
 - Overfitting when training on ground-truth data.
 - Better generalization than ISMRM 2015 Challenge contestants when training on
 MITK output.
@@ -147,7 +147,7 @@ algorithms.
 # Comments
 
 - Looks heavily inspired (including network architecture and tracking
-parameters) by Poulin *et al.* [^4].
+parameters) by Poulin *et al.* [Poulin:2018:MICCAI].
 - The way the assessment is made seems not to be a standardized way to do it,
 using MITK both to generate a training dataset and its results being reported
 in the comparison.
@@ -164,21 +164,22 @@ results.
 
 # References
 
-[^1]: Klaus Maier-Hein, Peter Neher, Jean-Christophe Houde, Marc-Alexandre
-Côté, Eleftherios Garyfallidis, Jidan Zhong, Maxime Chamberland, Fang-Cheng Yeh,
-Ying Chia Lin, Qing Ji, et al. Tractography-based connectomes are dominated by
-false-positive connections. biorxiv, page 084137, 2016.
+[Maier-Hein:2016:biorxiv]: Klaus Maier-Hein, Peter Neher, Jean-Christophe
+Houde, Marc-Alexandre Côté, Eleftherios Garyfallidis, Jidan Zhong, Maxime
+Chamberland, Fang-Cheng Yeh, Ying Chia Lin, Qing Ji, et al. Tractography-based
+connectomes are dominated by false-positive connections. biorxiv, page 084137,
+2016.
 
-[^2]: The Medical Imaging Interaction Toolkit (MITK):
+[MITK]: The Medical Imaging Interaction Toolkit (MITK):
 http://mitk.org/wiki/The_Medical_Imaging_Interaction_Toolkit_(MITK)
 
-[^3]: Marc-Alexandre Côté, Gabriel Girard, Arnaud Boré, Eleftherios
+[Cote:2013:MIA]: Marc-Alexandre Côté, Gabriel Girard, Arnaud Boré, Eleftherios
 Garyfallidis, Jean-Christophe Houde, and Maxime Descoteaux. Tractometer:
 towards validation of tractography pipelines. Medical image analysis,
 17(7):844–857, 2013.
 
-[^4]: Philippe Poulin, Marc-Alexandre Côté, Jean-Christophe Houde,
-Laurent Petit, Peter F Neher, Klaus H Maier-Hein, Hugo Larochelle, and Maxime
-Descoteaux. Learn to track: Deep learning for tractography. In International
-Conference on Medical Image Computing and Computer-Assisted Intervention, pages
-540–547. Springer, 2017.
+[Poulin:2018:MICCAI]: Philippe Poulin, Marc-Alexandre Côté, Jean-Christophe
+Houde, Laurent Petit, Peter F Neher, Klaus H Maier-Hein, Hugo Larochelle, and
+Maxime Descoteaux. Learn to track: Deep learning for tractography. In
+International Conference on Medical Image Computing and Computer-Assisted
+Intervention, pages 540–547. Springer, 2017.


### PR DESCRIPTION
Improve self review cross-references:
- Use names rather than numbers for the anchors.
- Remove the `References` section heading from NeuroNet.