### PR TITLE
ENH: Add pre-commit hooks

### DIFF
--- a/.hooks-config.bash
+++ b/.hooks-config.bash
@@ -1,4 +1,20 @@
-# Loaded by .git/hooks/(pre-commit|commit-msg|prepare-commit-msg)
-# during git commit after local hooks have been installed.
+#!/bin/bash
 
-hooks_chain_pre_commit="utils/hooks/pre-commit"
+# Make sure we are inside the repository
+cd "${BASH_SOURCE%/*}" &&
+
+
+echo "Configuring git hooks..."
+
+hooks_folder=$(pwd)'/utils/hooks/'
+
+mayor=$(git --version | grep -o '[0-9.]*' | awk -F \. {'print $1'})
+minor=$(git --version | grep -o '[0-9.]*' | awk -F \. {'print $2'})
+
+if [ $mayor -eq "2" ] && [ $minor -lt "9" ]; then
+  find $hooks_folder -type f -exec ln -sf ../../{} .git/hooks/ \;
+else
+  git config core.hooksPath $hooks_folder
+fi
+
+echo "Done configuring git hooks."

--- a/.hooks-config.bash
+++ b/.hooks-config.bash
@@ -1,4 +1,4 @@
 # Loaded by .git/hooks/(pre-commit|commit-msg|prepare-commit-msg)
 # during git commit after local hooks have been installed.
 
-hooks_chain_pre_commit="Utils/hooks/pre-commit"
+hooks_chain_pre_commit="utils/hooks/pre-commit"

--- a/.hooks-config.bash
+++ b/.hooks-config.bash
@@ -1,0 +1,4 @@
+# Loaded by .git/hooks/(pre-commit|commit-msg|prepare-commit-msg)
+# during git commit after local hooks have been installed.
+
+hooks_chain_pre_commit="Utils/hooks/pre-commit"

--- a/how-to.md
+++ b/how-to.md
@@ -10,7 +10,8 @@ The process for adding reviews is _git-centric_. Basically, **you just need to a
 
 0.  Send an e-mail to Pierre-Marc Jodoin asking him to include you as a member of the [github.com/vitalab](https://github.com/vitalab) organization.
 1.  Clone the [`vitalab.github.io`](https://github.com/vitalab/vitalab.github.io) repo on your computer.
-2.  Determine the category in which you will add your post. Categories are managed using folders :  
+2.  Set up the `pre-commit` hooks by executing the `utils/setup_hooks.sh` script.
+3.  Determine the category in which you will add your post. Categories are managed using folders :  
 
     ~~~
     _posts/           # A post added here will have no category
@@ -20,9 +21,9 @@ The process for adding reviews is _git-centric_. Basically, **you just need to a
         _posts/       # Same thing for the "machine-learning" category
     ...               # There are other categories, you can add one too.
     ~~~
-3.  Create a file `YYYY-MM-DD-title-of-your-review.markdown` and put it in right folder (see above).  
+4.  Create a file `YYYY-MM-DD-title-of-your-review.markdown` and put it in right folder (see above).  
 It is **important that you respect this format : date at the beginning and no spaces.** Else the page won't build properly. Here is an example of a valid name : `2017-01-31-going-deeper-with-convolutions.markdown`.
-4.  Use the `review` template file in the [`templates`](https://github.com/vitalab/vitalab.github.io/tree/master/templates/review_template.md )
+5.  Use the `review` template file in the [`templates`](https://github.com/vitalab/vitalab.github.io/tree/master/templates/review_template.md )
 as a starting point and do your review.
 
     A minimal working review example may look like:
@@ -87,10 +88,10 @@ as a starting point and do your review.
 
 You can [preview your post while you write it](#how-to-preview-your-post-locally) ; see the next section about this.\\
 
-5.  **Make a new branch**, commit your file and push your branch.
-6.  [**Create a pull request**](https://github.com/vitalab/vitalab.github.io/compare) on the repo's github page.
-7.  **Add reviewers**: everyone that you think are knowledgeable about the subject or simply would be interested in your review.
-8.  When every reviewer approved your branch, **merge your branch and delete it**.
+6.  **Make a new branch**, commit your file and push your branch.
+7.  [**Create a pull request**](https://github.com/vitalab/vitalab.github.io/compare) on the repo's github page.
+8.  **Add reviewers**: everyone that you think are knowledgeable about the subject or simply would be interested in your review.
+9.  When every reviewer approved your branch, **merge your branch and delete it**.
 
 ## How to preview your post locally
 

--- a/utils/check_cross_ref_images.sh
+++ b/utils/check_cross_ref_images.sh
@@ -1,6 +1,40 @@
 #!/bin/bash
 
+# Utility functions
+usage() {
+cat << EOF
+Usage: $0 <file_list>
+Use this script to check the existence of the cross-references files.
+EOF
+}
+
+die() {
+  echo "$@" 1>&2; exit 1
+}
+
+# Parse arguments
+help=false
+folder_id=""
+while test $# -gt 0;
+do
+  opt="$1";
+  case "$opt" in
+    "-h"|"--help")
+      shift;
+      help=true
+      break;;
+    *)
+      break;;
+  esac
+done
+
 files=("$@")
+
+if test "${files}" = "" || $help; then
+  usage
+  exit 1
+fi
+
 
 images_list=()
 

--- a/utils/check_cross_ref_images.sh
+++ b/utils/check_cross_ref_images.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
+files=("$@")
+
 images_list=()
 
 check_files_exist() {
+  local file
   for file in "${images_list[@]}"; do
     abs_filename="$(pwd)$file"
     if [ ! -f "$abs_filename" ]; then
@@ -15,14 +18,20 @@ check_files_exist() {
 cd "${BASH_SOURCE%/*}" &&
 cd ..
 
-# Look for the cross-referenced images in the Markdown file of the commit
-post_added=$(git diff-index --diff-filter=A --cached HEAD -- '*.md')
-pattern=".*\!\[.*\](\(.*\))"
-IFS=$'\n' images_list=($(sed -n -e "s/$pattern/\1/p" $post_added))
 
-check_files_exist
+for file in "${files[@]}"; do
 
-pattern="<img src=[^\"]*\"\([^\"]*\)\".*"
-IFS=$'\n' images_list=($(sed -n -e "s/$pattern/\1/p" $post_added))
+  echo $file
 
-check_files_exist
+  # Look for the cross-referenced images in the files
+  pattern=".*\!\[.*\](\(.*\))"
+  IFS=$'\n' images_list=($(sed -n -e "s/$pattern/\1/p" $file))
+
+  check_files_exist
+
+  pattern="<img src=[^\"]*\"\([^\"]*\)\".*"
+  IFS=$'\n' images_list=($(sed -n -e "s/$pattern/\1/p" $file))
+
+  check_files_exist
+
+done

--- a/utils/check_cross_ref_images.sh
+++ b/utils/check_cross_ref_images.sh
@@ -40,11 +40,11 @@ status=0
 non_existing_files=0
 
 check_files_exist() {
-  local file
-  for file in "${images_list[@]}"; do
-    abs_filename="$(pwd)$file"
+  local cross_ref_file
+  for cross_ref_file in "${images_list[@]}"; do
+    abs_filename="$(pwd)$cross_ref_file"
     if [ ! -f "$abs_filename" ]; then
-      echo "'$file' does not exist as a file."
+      non_existing_cross_ref_files+=("$cross_ref_file")
       ((non_existing_files++))
     fi
   done
@@ -59,7 +59,7 @@ images_list=()
 
 for file in "${files[@]}"; do
 
-  echo $file
+  non_existing_cross_ref_files=()
 
   # Look for the cross-referenced images in the files
   pattern=".*\!\[.*\](\(.*\))"
@@ -71,6 +71,19 @@ for file in "${files[@]}"; do
   IFS=$'\n' images_list=($(sed -n -e "s/$pattern/\1/p" $file))
 
   check_files_exist
+
+  if [[ ${#non_existing_cross_ref_files} -ne 0 ]]; then
+    echo $file
+    IFS=$'\n' echo "${non_existing_cross_ref_files[*]}"
+
+    if (( $non_existing_files == 1 )); then
+      echo "does not exist as a file."
+      echo "Please, add it or remove its references."
+    else
+      echo "do not exist as files."
+      echo "Please, add them or remove their references."
+    fi
+  fi
 
 done
 

--- a/utils/check_cross_ref_images.sh
+++ b/utils/check_cross_ref_images.sh
@@ -15,10 +15,14 @@ check_files_exist() {
 cd "${BASH_SOURCE%/*}" &&
 cd ..
 
-# Look for the tags in the Markdown file of the commit
+# Look for the cross-referenced images in the Markdown file of the commit
 post_added=$(git diff-index --diff-filter=A --cached HEAD -- '*.md')
-
 pattern=".*\!\[.*\](\(.*\))"
+IFS=$'\n' images_list=($(sed -n -e "s/$pattern/\1/p" $post_added))
+
+check_files_exist
+
+pattern="<img src=[^\"]*\"\([^\"]*\)\".*"
 IFS=$'\n' images_list=($(sed -n -e "s/$pattern/\1/p" $post_added))
 
 check_files_exist

--- a/utils/check_cross_ref_images.sh
+++ b/utils/check_cross_ref_images.sh
@@ -36,7 +36,8 @@ if test "${files}" = "" || $help; then
 fi
 
 
-images_list=()
+status=0
+non_existing_files=0
 
 check_files_exist() {
   local file
@@ -44,6 +45,7 @@ check_files_exist() {
     abs_filename="$(pwd)$file"
     if [ ! -f "$abs_filename" ]; then
       echo "'$file' does not exist as a file."
+      ((non_existing_files++))
     fi
   done
 }
@@ -52,6 +54,8 @@ check_files_exist() {
 cd "${BASH_SOURCE%/*}" &&
 cd ..
 
+
+images_list=()
 
 for file in "${files[@]}"; do
 
@@ -69,3 +73,9 @@ for file in "${files[@]}"; do
   check_files_exist
 
 done
+
+if [[ $non_existing_files -ne 0 ]]; then
+  status=1
+fi
+
+exit $status

--- a/utils/check_cross_ref_images.sh
+++ b/utils/check_cross_ref_images.sh
@@ -67,7 +67,7 @@ for file in "${files[@]}"; do
 
   check_files_exist
 
-  pattern="<img src=[^\"]*\"\([^\"]*\)\".*"
+  pattern=".*<img src=[^\"]*\"\([^\"]*\)\".*"
   IFS=$'\n' images_list=($(sed -n -e "s/$pattern/\1/p" $file))
 
   check_files_exist

--- a/utils/check_cross_ref_images.sh
+++ b/utils/check_cross_ref_images.sh
@@ -62,8 +62,8 @@ for file in "${files[@]}"; do
   non_existing_cross_ref_files=()
 
   # Look for the cross-referenced images in the files
-  pattern=".*\!\[.*\](\(.*\))"
-  IFS=$'\n' images_list=($(sed -n -e "s/$pattern/\1/p" $file))
+  pattern=".*\!(\[.?\])(\(?)([^]]*)(\))(.*)"
+  IFS=$'\n' images_list=($(sed -n -r "s/$pattern/\3/p" $file))
 
   check_files_exist
 

--- a/utils/check_cross_ref_images.sh
+++ b/utils/check_cross_ref_images.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+images_list=()
+
+check_files_exist() {
+  for file in "${images_list[@]}"; do
+    abs_filename="$(pwd)$file"
+    if [ ! -f "$abs_filename" ]; then
+      echo "'$file' does not exist as a file."
+    fi
+  done
+}
+
+# Make sure we are inside the repository
+cd "${BASH_SOURCE%/*}" &&
+cd ..
+
+# Look for the tags in the Markdown file of the commit
+post_added=$(git diff-index --diff-filter=A --cached HEAD -- '*.md')
+
+pattern=".*\!\[.*\](\(.*\))"
+IFS=$'\n' images_list=($(sed -n -e "s/$pattern/\1/p" $post_added))
+
+check_files_exist

--- a/utils/check_tags.sh
+++ b/utils/check_tags.sh
@@ -80,7 +80,10 @@ for file in "${files[@]}"; do
     echo $file
     echo "The following tags are not contained in the $tags_file file:"
     echo ${not_in_tag_list[@]}
-    echo "Please, add them before committing."
+    echo "Please, check for potential typos. If there are no typos, the"\
+    " missing tags would need to be added to the $tags_file file before"\
+    " committing. If you are unsure that this addition would be justified,"\
+    " please ask on the team's Slack channel."
   fi
 
 done

--- a/utils/check_tags.sh
+++ b/utils/check_tags.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+not_in_tag_list=()
+
+find_non_existing_tags() {
+  for item1 in "${article_tags[@]}"; do
+    for item2 in "${tag_list[@]}"; do
+      [[ $item1 == "$item2" ]] && continue 2
+    done
+
+    # If we reached here, nothing matched
+    not_in_tag_list+=( "$item1" )
+  done
+}
+
+# Make sure we are inside the repository
+cd "${BASH_SOURCE%/*}" &&
+cd ..
+
+tags_file='./_data/tags.yml'
+
+# Read the tags
+pattern='\(-[[:blank:]]\)\(.*\)'
+IFS=$'\n' tag_list=($(sed -n -e "s/$pattern/\2/p" $tags_file))
+
+# Look for the tags in the Markdown file of the commit
+post_added=$(git diff-index --diff-filter=A --cached HEAD -- '*.md')
+pattern='(tags:\s*)\"?([^\"]*)\"?/'
+IFS=$', ' article_tags=($(sed -n -E "s/$pattern \2/p" $post_added))
+
+find_non_existing_tags
+
+echo "The following tags are not contained in the $tags_file file:"
+echo ${not_in_tag_list[@]}
+echo "Please, add them before committing."

--- a/utils/check_tags.sh
+++ b/utils/check_tags.sh
@@ -40,7 +40,6 @@ fi
 status=0
 non_existing_tags=0
 
-not_in_tag_list=()
 
 find_non_existing_tags() {
   for item1 in "${article_tags[@]}"; do
@@ -53,11 +52,6 @@ find_non_existing_tags() {
     ((non_existing_tags++))
   done
 
-  if [[ $non_existing_tags -ne 0 ]]; then
-    echo "The following tags are not contained in the $tags_file file:"
-    echo ${not_in_tag_list[@]}
-    echo "Please, add them before committing."
-  fi
 }
 
 # Make sure we are inside the repository
@@ -74,13 +68,20 @@ IFS=$'\n' tag_list=($(sed -n -e "s/$pattern/\2/p" $tags_file))
 
 for file in "${files[@]}"; do
 
-  echo $file
+  not_in_tag_list=()
 
   # Look for the tags in the files
   pattern='(tags:\s*)\"?([^\"]*)\"?/'
   IFS=$', ' article_tags=($(sed -n -E "s/$pattern \2/p" $file))
 
   find_non_existing_tags
+
+  if [[ ${#not_in_tag_list[@]} -ne 0 ]]; then
+    echo $file
+    echo "The following tags are not contained in the $tags_file file:"
+    echo ${not_in_tag_list[@]}
+    echo "Please, add them before committing."
+  fi
 
 done
 

--- a/utils/check_tags.sh
+++ b/utils/check_tags.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+files=("$@")
+
 not_in_tag_list=()
 
 find_non_existing_tags() {
@@ -17,19 +19,26 @@ find_non_existing_tags() {
 cd "${BASH_SOURCE%/*}" &&
 cd ..
 
+
 tags_file='./_data/tags.yml'
 
 # Read the tags
 pattern='\(-[[:blank:]]\)\(.*\)'
 IFS=$'\n' tag_list=($(sed -n -e "s/$pattern/\2/p" $tags_file))
 
-# Look for the tags in the Markdown file of the commit
-post_added=$(git diff-index --diff-filter=A --cached HEAD -- '*.md')
-pattern='(tags:\s*)\"?([^\"]*)\"?/'
-IFS=$', ' article_tags=($(sed -n -E "s/$pattern \2/p" $post_added))
 
-find_non_existing_tags
+for file in "${files[@]}"; do
 
-echo "The following tags are not contained in the $tags_file file:"
-echo ${not_in_tag_list[@]}
-echo "Please, add them before committing."
+  echo $file
+
+  # Look for the tags in the files
+  pattern='(tags:\s*)\"?([^\"]*)\"?/'
+  IFS=$', ' article_tags=($(sed -n -E "s/$pattern \2/p" $file))
+
+  find_non_existing_tags
+
+  echo "The following tags are not contained in the $tags_file file:"
+  echo ${not_in_tag_list[@]}
+  echo "Please, add them before committing."
+
+done

--- a/utils/check_tags.sh
+++ b/utils/check_tags.sh
@@ -1,6 +1,41 @@
 #!/bin/bash
 
+# Utility functions
+usage() {
+cat << EOF
+Usage: $0 <file_list>
+Use this script to check that the tags contained exist in the './_data/tags.yml'
+file.
+EOF
+}
+
+die() {
+  echo "$@" 1>&2; exit 1
+}
+
+# Parse arguments
+help=false
+folder_id=""
+while test $# -gt 0;
+do
+  opt="$1";
+  case "$opt" in
+    "-h"|"--help")
+      shift;
+      help=true
+      break;;
+    *)
+      break;;
+  esac
+done
+
 files=("$@")
+
+if test "${files}" = "" || $help; then
+  usage
+  exit 1
+fi
+
 
 not_in_tag_list=()
 

--- a/utils/check_tags.sh
+++ b/utils/check_tags.sh
@@ -37,6 +37,9 @@ if test "${files}" = "" || $help; then
 fi
 
 
+status=0
+non_existing_tags=0
+
 not_in_tag_list=()
 
 find_non_existing_tags() {
@@ -46,8 +49,15 @@ find_non_existing_tags() {
     done
 
     # If we reached here, nothing matched
-    not_in_tag_list+=( "$item1" )
+    not_in_tag_list+=("$item1")
+    ((non_existing_tags++))
   done
+
+  if [[ $non_existing_tags -ne 0 ]]; then
+    echo "The following tags are not contained in the $tags_file file:"
+    echo ${not_in_tag_list[@]}
+    echo "Please, add them before committing."
+  fi
 }
 
 # Make sure we are inside the repository
@@ -72,8 +82,11 @@ for file in "${files[@]}"; do
 
   find_non_existing_tags
 
-  echo "The following tags are not contained in the $tags_file file:"
-  echo ${not_in_tag_list[@]}
-  echo "Please, add them before committing."
-
 done
+
+
+if [[ $non_existing_tags -ne 0 ]]; then
+  status=1
+fi
+
+exit $status

--- a/utils/hooks/pre-commit
+++ b/utils/hooks/pre-commit
@@ -1,7 +1,11 @@
 #!/bin/bash
 
+# Look for the Markdown files added to the commit
+files_added=$(git diff-index --diff-filter=A --cached HEAD -- '*.md')
+
+# Loop over the scripts
 for hook in "check_tags.sh" "check_cross_ref_images.sh"; do
-  sh "$(pwd)/../$hook"
+  sh "$(pwd)/../$hook ${files_added[@]}"
   if [ $? -ne 0 ]; then
     exit 1
   fi

--- a/utils/hooks/pre-commit
+++ b/utils/hooks/pre-commit
@@ -8,12 +8,12 @@ scripts_folder=$(pwd)'/utils/'
 hook_scripts=("check_tags.sh" "check_cross_ref_images.sh")
 
 # Look for the added or modified Markdown files
-files_added=($(git diff-index --diff-filter=AM --cached HEAD --name-only -- '*.md'))
+files=($(git diff-index --diff-filter=AM --cached HEAD --name-only -- '*.md'))
 
 # Loop over the scripts if the array is not empty
-if [ ${files_added[@]} ]; then
+if [[ ${files[@]} ]]; then
   for hook in "${hook_scripts[@]}"; do
-    bash $scripts_folder$hook ${files_added[@]}
+    bash $scripts_folder$hook ${files[@]}
     if [ $? -ne 0 ]; then
       exit 1
     fi

--- a/utils/hooks/pre-commit
+++ b/utils/hooks/pre-commit
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+for hook in "check_tags.sh" "check_cross_ref_images.sh"; do
+  sh "$(pwd)/../$hook"
+  if [ $? -ne 0 ]; then
+    exit 1
+  fi
+done

--- a/utils/hooks/pre-commit
+++ b/utils/hooks/pre-commit
@@ -7,8 +7,10 @@ cd ../..
 scripts_folder=$(pwd)'/utils/'
 hook_scripts=("check_tags.sh" "check_cross_ref_images.sh")
 
+repo_root_path=$(git rev-parse --show-toplevel)
+
 # Look for the added or modified Markdown files
-files=($(git diff-index --diff-filter=AM --cached HEAD --name-only -- '*.md'))
+files=($(git diff-index --diff-filter=AM --cached HEAD --name-only -- '*.md' ":(exclude)$repo_root_path/*.md"))
 
 # Loop over the scripts if the array is not empty
 if [[ ${files[@]} ]]; then

--- a/utils/hooks/pre-commit
+++ b/utils/hooks/pre-commit
@@ -1,12 +1,21 @@
 #!/bin/bash
 
-# Look for the Markdown files added to the commit
-files_added=$(git diff-index --diff-filter=A --cached HEAD -- '*.md')
+# Make sure we are inside the repository.
+cd "${BASH_SOURCE%/*}" &&
+cd ../..
 
-# Loop over the scripts
-for hook in "check_tags.sh" "check_cross_ref_images.sh"; do
-  sh "$(pwd)/../$hook ${files_added[@]}"
-  if [ $? -ne 0 ]; then
-    exit 1
-  fi
-done
+scripts_folder=$(pwd)'/utils/'
+hook_scripts=("check_tags.sh" "check_cross_ref_images.sh")
+
+# Look for the added or modified Markdown files
+files_added=($(git diff-index --diff-filter=AM --cached HEAD --name-only -- '*.md'))
+
+# Loop over the scripts if the array is not empty
+if [ ${files_added[@]} ]; then
+  for hook in "${hook_scripts[@]}"; do
+    bash $scripts_folder$hook ${files_added[@]}
+    if [ $? -ne 0 ]; then
+      exit 1
+    fi
+  done
+fi

--- a/utils/setup_hooks.sh
+++ b/utils/setup_hooks.sh
@@ -6,7 +6,7 @@ cd "${BASH_SOURCE%/*}" &&
 
 echo "Configuring git hooks..."
 
-hooks_folder=$(pwd)'/hooks/'
+hooks_folder=$(pwd)'/hooks'
 
 mayor=$(git --version | grep -o '[0-9.]*' | awk -F \. {'print $1'})
 minor=$(git --version | grep -o '[0-9.]*' | awk -F \. {'print $2'})

--- a/utils/setup_hooks.sh
+++ b/utils/setup_hooks.sh
@@ -8,10 +8,10 @@ echo "Configuring git hooks..."
 
 hooks_folder=$(pwd)'/hooks'
 
-mayor=$(git --version | grep -o '[0-9.]*' | awk -F \. {'print $1'})
+major=$(git --version | grep -o '[0-9.]*' | awk -F \. {'print $1'})
 minor=$(git --version | grep -o '[0-9.]*' | awk -F \. {'print $2'})
 
-if [ $mayor -eq "2" ] && [ $minor -lt "9" ]; then
+if [ $major -eq "2" ] && [ $minor -lt "9" ]; then
   find $hooks_folder -type f -exec ln -sf ../../{} .git/hooks/ \;
 else
   git config core.hooksPath $hooks_folder

--- a/utils/setup_hooks.sh
+++ b/utils/setup_hooks.sh
@@ -6,7 +6,7 @@ cd "${BASH_SOURCE%/*}" &&
 
 echo "Configuring git hooks..."
 
-hooks_folder=$(pwd)'/utils/hooks/'
+hooks_folder=$(pwd)'/hooks/'
 
 mayor=$(git --version | grep -o '[0-9.]*' | awk -F \. {'print $1'})
 minor=$(git --version | grep -o '[0-9.]*' | awk -F \. {'print $2'})


### PR DESCRIPTION
Add pre-commit hooks.

Specifically, add hooks that call to separate, re-usable scripts to:
- Check that a review article contains tags that exist in the
  `_data/tags.yml` file.
- Check that the cross-refenced images (files) exist.

Fixes #365.