### PR TITLE
ENH: Add a `.gitattributes` file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Convert line endings to `LF` when committing
+*.md crlf=input


### PR DESCRIPTION
Add a `.gitattributes` file to configure git attributes.

Add configuration options to  convert `CRLF` to `LF` when
committing.