### PR TITLE
BUG: Fix cross-references that were left-behind

### DIFF
--- a/_data/tags.yml
+++ b/_data/tags.yml
@@ -69,8 +69,8 @@ tags:
 - tractometry
 - traffic
 - transfer-learning
+- unsupervised
 - VAE
 - video-analysis
-- unsupervised
 - weakly-supervised
 - white-matter

--- a/article/_posts/2017-03-29-lenet.md
+++ b/article/_posts/2017-03-29-lenet.md
@@ -18,7 +18,7 @@ See [Yann LeCun's page about LeNet](http://yann.lecun.com/exdb/lenet/) for demos
 
 **Figure 1**: The LeNet-5 Architecture.
 
-|  ![](/deep-learning/images/lenet/f3spiky.gif)  |  ![](/article/images/lenet/arot.gif)  |
-|  ![](/deep-learning/images/lenet/anoise4.gif)  |  ![](/article/images/lenet/a384.gif)  |
+|  ![](/article/images/lenet/f3spiky.gif)  |  ![](/article/images/lenet/arot.gif)  |
+|  ![](/article/images/lenet/anoise4.gif)  |  ![](/article/images/lenet/a384.gif)  |
 
 **Figure 2**: (Top and bottom-left) This network showed impressive robustness to various distortions, i.e. unusual patterns, rotation, noise, etc. (Bottom-right) LeNet applied to number sequence recognition. ([Source](http://yann.lecun.com/exdb/lenet/))

--- a/article/_posts/2017-08-22-lookup-cnn.md
+++ b/article/_posts/2017-08-22-lookup-cnn.md
@@ -12,7 +12,7 @@ cite:
 
 LCNN is a novel layer that can replace any convolutional layer. The main thing is that a filter is "decomposed" as a linear combination of parts from a dictionary. The ability to tune the dictionary size and the number of elements in the linear combination allows an **efficiency/accuracy trade-off** (see Figure 3). In addition, the authors argue that LCNN has an advantage in **few-shot learning** and **few-iteration learning** settings.
 
-![](/deep-learning/images/lookup-cnn/fig3.png)
+![](/article/images/lookup-cnn/fig3.png)
 
 # Filter Construction
 
@@ -27,7 +27,7 @@ Then, we can formulate the construction as follows:
 
 $$ \bold{W}_{[:,r,c]} = \sum_{t=1}^s \bold{C}_{[t,r,c]} \cdot \bold{D}_{[\bold{I}_{[t,r,c]},:]} $$
 
-![](/deep-learning/images/lookup-cnn/fig1.png)
+![](/article/images/lookup-cnn/fig1.png)
 
 # Fast Convolution using a Shared Dictionary
 
@@ -41,10 +41,10 @@ During training, we learn $$ \bold{D} $$ and $$ \bold{P} $$. To obtain a tensor 
 
 The authors argue that this layer architecture has a performance advantage in few-shot learning settings, as we can see in the following plot (extracted from Figure 4).
 
-![](/deep-learning/images/lookup-cnn/fig4.png)
+![](/article/images/lookup-cnn/fig4.png)
 
 # Few-iteration learning
 
 The authors also argue that LCNN can learn more in the first iterations of training than an ordinary CNN. In one experiment, they transferred the dictionary learned with a shallow network to a deeper network and only trained $$ \bold{I} $$ and $$ \bold{C} $$. See Figure 5 for the learning curves.
 
-![](/deep-learning/images/lookup-cnn/fig5.png)
+![](/article/images/lookup-cnn/fig5.png)

--- a/article/_posts/2017-08-30-mimicking.md
+++ b/article/_posts/2017-08-30-mimicking.md
@@ -18,4 +18,4 @@ The authors did not compute the loss on empty regions. They mask the feature map
 
 To further speed up the network, the small network has an input size reduced by half from the original. The final feature map is then upsampled by deconvolution.
 
-![](/deep-learning/images/mimicking/model.png)
+![](/article/images/mimicking/model.png)

--- a/article/_posts/2018-03-02-prune_your_network.md
+++ b/article/_posts/2018-03-02-prune_your_network.md
@@ -14,17 +14,17 @@ This paper proposes a network pruning method based on a three-step process.  As 
 the connectivity via normal network training. Unlike conventional training, however, it does not learn the final values of the weights, but rather learns which connections are important.  The second step is to prune the low-weight connections. All connections with weights below a threshold are removed from the network — converting a dense network into a sparse network, as shown in Figure 3. The final step retrains the network to learn the final weights for the remaining
 sparse connections. This step is critical. If the pruned network is used without retraining, accuracy is significantly impacted
 
-![](/deep-learning/images/pruning2015/sc01.png)
+![](/article/images/pruning2015/sc01.png)
 
 ## Results
 
 The method is both simple and has good compression rates as shown in Table 1.
 
-![](/deep-learning/images/pruning2015/sc02.png)
+![](/article/images/pruning2015/sc02.png)
 
 They also show that the kind of regularization used can have an important impact on the accuracy.
 
-![](/deep-learning/images/pruning2015/sc03.png)
+![](/article/images/pruning2015/sc03.png)
 
 
 

--- a/article/_posts/2018-04-12-spars_ensemble.md
+++ b/article/_posts/2018-04-12-spars_ensemble.md
@@ -17,9 +17,9 @@ The authors, in the first phase, run an SG-MCMC to draw an ensemble of samples f
 of network parameters. In the second phase, weight-pruning is applied to each sampled networks and then retraining over the remained connections.
 For each test point $hat{x}$, predictive distribution is:
 
-<img src="/deep-learning/images/mcmc/1.png" width="400">
+<img src="/article/images/mcmc/1.png" width="400">
 
-<img src="/deep-learning/images/mcmc/7.png" width="800">
+<img src="/article/images/mcmc/7.png" width="800">
 
 
 The parameters are approximated by Mont Carlo which will be sampled from posterior distribution of network parameters.
@@ -30,23 +30,23 @@ MCMC is a common sampling but is not good for large datasets. Stochastic Gradien
 
 
 
-<img src="/deep-learning/images/mcmc/2.png" width="600">
+<img src="/article/images/mcmc/2.png" width="600">
 
 
 
 After all the models are collected, authors use a simple pruning rule to reduce the model size as well as the computation cost with finding the network connections whose weights are below a certain threshold and removing them away. Now coming to next phase, with multiple sparse models, there is zero positions in weight matrics is an issue, so authors use Sparse Structure Ensemble (SSE) which employe group lasso regularization, proposes to do feature selection in group level, which means keeping or removing all the parameters in a group simultaneously to achieve structured sparsity corresponding to grouping strategy and penalize unimportant filter and channels. So, group lasso regularization can be formulated as :
 
-<img src="/deep-learning/images/mcmc/3.png" width="300">
+<img src="/article/images/mcmc/3.png" width="300">
 
 where $\theta$ is a group of weights, G is the number of groups, dim($\theta$) is number of weights.
 
 
-<img src="/deep-learning/images/mcmc/4.png" width="600">
+<img src="/article/images/mcmc/4.png" width="600">
 
 The SSE is learned on both Fully Neural Network and LSTM. So, the group for FNN is all the outgoing connections from a single neuron (input or hidden) together, it means if neuron’s outputs are all zeros, it makes no contribution to the next layer and can be removed which reduces the rows and columns of weight matrices between layers. In Lstm, Since the input and hidden units are used four times, keeping two index lists during pruning to record the remained rows and columns for each weight matrix. When doing computations, just using partial units to update partial dimensions of the gates according to the index lists. The first grouping strategy is to group each row and each column for the four weight matrices separately (is named untied) and the second is getting a W matrix which concatenated horizontally of four weight and group each row and column of W as a second grouping (tied) strategy and uses two indexes instead four indexes. The other strategy would be Intrinsic Sparse Structures (ISS), is proposed to reduce the hidden size by grouping all the weights associated with a certain hidden unit together and removing them simultaneously.
 
-<img src="/deep-learning/images/mcmc/5.png" width="700">
-<img src="/deep-learning/images/mcmc/6.png" width="700">
+<img src="/article/images/mcmc/5.png" width="700">
+<img src="/article/images/mcmc/6.png" width="700">
 
 
 ### Experiments
@@ -54,12 +54,12 @@ The result is shown in two parts: SSE of FNNs for image classification task on M
 LSTM models, language modeling task on Penn TreeBank corpus.
 
 
-<img src="/deep-learning/images/mcmc/8.png" width="800">
+<img src="/article/images/mcmc/8.png" width="800">
 
-<img src="/deep-learning/images/mcmc/9.png" width="800">
+<img src="/article/images/mcmc/9.png" width="800">
 
 
-<img src="/deep-learning/images/mcmc/10.png" width="800">
+<img src="/article/images/mcmc/10.png" width="800">
 
 
 

--- a/article/_posts/2018-05-17-lottery-ticket-hypothesis.md
+++ b/article/_posts/2018-05-17-lottery-ticket-hypothesis.md
@@ -28,8 +28,8 @@ The hypothesis is empirically supported as follows:
 
 # Pics or it didn't happen
 
-![](/deep-learning/images/lottery/fig11.png)
-![](/deep-learning/images/lottery/fig14.png)
+![](/article/images/lottery/fig11.png)
+![](/article/images/lottery/fig14.png)
 
 # Caveats
 

--- a/article/_posts/2018-06-29-budgeted-CNN.md
+++ b/article/_posts/2018-06-29-budgeted-CNN.md
@@ -17,7 +17,7 @@ The authors propose to use a Reinforcement Learning scheme to find the most effi
 
 First, the authors present two "Super Network" architectures, that represent the space in which the optimal solution is sought.
 
-![](/deep-learning/images/budgeted-CNN/supernets.png)
+![](/article/images/budgeted-CNN/supernets.png)
 
 Any architecture of their scope can be seen as the result of an Hadamard product between the direct acyclic graph (DAG) of the Super Network and a binary matrix H that encodes which connections are kept and which are deactivated.
 
@@ -44,6 +44,6 @@ The authors propose to either optimize the number of operations, the number of p
 
 Here are some architectures found as optimal :
 
-![](/deep-learning/images/budgeted-CNN/archi.png)
+![](/article/images/budgeted-CNN/archi.png)
 
 On all applications, they show that they can either obtain the same performance as the State-of-the-Art with a lower cost architecture (ex: a network that contains 4 times less parameters) or outperform it with a slightly bigger budget.

--- a/article/_posts/2018-07-24-learning-compression.md
+++ b/article/_posts/2018-07-24-learning-compression.md
@@ -16,7 +16,7 @@ The authors propose a method for obtaining resource-efficient neural networks. T
 
 The authors study 3 pruning costs: `C(w) = ||w||_p where p ∈ [0, 1, 2]`. These costs are used with 2 different approaches: the constraint form and the penalty form.
 
-![](/deep-learning/images/learning-compression/eq1.png)
+![](/article/images/learning-compression/eq1.png)
 
 ## Constraint form
 
@@ -26,7 +26,7 @@ $$ w $$ are the trainable weights of the network, and $$ \theta $$ is a set of t
 * $$ \theta $$ is optimized to respect the pruning constraint
 * $$ w, \theta $$ are optimized to be equal
 
-![](/deep-learning/images/learning-compression/eq2.png)
+![](/article/images/learning-compression/eq2.png)
 
 Alterning optimization is used. There is a Learning step and a Compression step. In the learning step, we minimize the following:
 
@@ -50,7 +50,7 @@ With this method, it is possible to find networks respecting a budget with diffe
 
 Results are pretty good
 
-![](/deep-learning/images/learning-compression/fig4.png)
+![](/article/images/learning-compression/fig4.png)
 
 # Reproducing the results
 

--- a/article/_posts/2018-08-17-block-drop.md
+++ b/article/_posts/2018-08-17-block-drop.md
@@ -12,12 +12,12 @@ cite:
 
 The authors propose a method that can predict, by looking at an image with a small CNN, which residual blocks to keep in a large Resnet at inference. According to the hypothesis that ResNets are ensembles of independent paths, blocks can be dropped while keeping useful signal going up to the classification head. The method is trained using RL; more specifically Policy Gradient.
 
-![](/deep-learning/images/blockdrop/fig1.png)
-![](/deep-learning/images/blockdrop/fig2.png)
+![](/article/images/blockdrop/fig1.png)
+![](/article/images/blockdrop/fig2.png)
 
 # Reward Function
 
-![](/deep-learning/images/blockdrop/eq3.png)
+![](/article/images/blockdrop/eq3.png)
 
 $$ \mathbf{u} $$ is the _policy vector_ describing which blocks to keep; $$ K $$ is the total number of blocks; and $$ \gamma $$ is the accuracy/speed trade-off parameter.
 
@@ -27,7 +27,7 @@ Since there is no ground truth for the _policy vectors_, it is very hard to lear
 
 # Quantitative Results
 
-![](/deep-learning/images/blockdrop/tab1.png)
+![](/article/images/blockdrop/tab1.png)
 
 With ResNet-101, an average speedup of 20% is obtained, which is an order of magnitude less than the $$ 2 \times $$ speedup typically yielded by pruning methods. However, BlockDrop is orthogonal to pruning; both approaches could be implemented at once.
 
@@ -35,8 +35,8 @@ With ResNet-101, an average speedup of 20% is obtained, which is an order of mag
 
 In a class-wise manner, the authors have selected 3 frequently occuring _policy vectors_, and show some of the corresponding instances:
 
-![](/deep-learning/images/blockdrop/fig4.png)
+![](/article/images/blockdrop/fig4.png)
 
 The authors also discuss the link between image difficulty and the number of blocks used:
 
-![](/deep-learning/images/blockdrop/fig5.png)
+![](/article/images/blockdrop/fig5.png)

--- a/article/_posts/2018-09-14-morphnet.md
+++ b/article/_posts/2018-09-14-morphnet.md
@@ -12,7 +12,7 @@ pdf: "https://arxiv.org/pdf/1711.06798.pdf"
 
 ### Introduction
 
-![](/deep-learning/images/morphNet/sc01.png)
+![](/article/images/morphNet/sc01.png)
 
 MorphNet is an approach to automate the design of neural network structures. MorphNet **iteratively shrinks and expands a network**, shrinking via a resource weighted 
 sparsifying regularizer on activations and expanding via a uniform multiplicative factor on all layers.  The proposed method has 3 advantages :
@@ -21,19 +21,19 @@ sparsifying regularizer on activations and expanding via a uniform multiplicativ
 * it can optimize a DNN structure targeting a specific resource, such as FLOPs per inference, while allowing the usage of untargeted resources such as model size (number of parameters), to grow;
 * it can learn a structure that improves performance while reducing the targeted resource usage
 
-![](/deep-learning/images/morphNet/sc02.png)
+![](/article/images/morphNet/sc02.png)
 
 ### Method
 
 Let $$ O_L $$ be the output wight (number of output feature maps) or layer L and $$ O_{1:M} $$ the total number of feature maps between the first and last layer (M is the index of the last layer).  They formalized their problem as follows:
 
 
-![](/deep-learning/images/morphNet/sc03.png)
+![](/article/images/morphNet/sc03.png)
 
 
 where the goal is to find the most accurate model (with the lowest loss) but which respect a limited resource.  For example here, the total number of flops must be below $$\zeta$$.  They then reformulate the problem as
 
-![](/deep-learning/images/morphNet/sc04.png)
+![](/article/images/morphNet/sc04.png)
 
 where $$g(\theta)$$ is a sparsity regularizer which depends on $$ F(O_{1:M} )$$.  Since their method has no guarantee to satisfy $$F(O_{1:M})$$ < $$ \zeta $$, they proposed Algo 1 where step 1 and 2 are compression steps and step 3 is an expansion step.
 
@@ -42,14 +42,14 @@ where $$g(\theta)$$ is a sparsity regularizer which depends on $$ F(O_{1:M} )$$.
 
 The regularizer is given by the following formula:
 
-![](/deep-learning/images/morphNet/sc05.png)  
+![](/article/images/morphNet/sc05.png)  
 
 where
 
-![](/deep-learning/images/morphNet/sc06.png)  
+![](/article/images/morphNet/sc06.png)  
 
 
-![](/deep-learning/images/morphNet/sc08.png)  
+![](/article/images/morphNet/sc08.png)  
 
 and $$f,g$$ is the spatial dimension of the filter at layer L and $$x,z $$ the spatial dimension of the feature maps of layer L.  Also, $$A_{L,i}$$ ($$B_{L,j}$$) is an indicator function which equals one
 if the i-th input (j-th output) of layer L is alive – not zeroed out.
@@ -59,7 +59,7 @@ if the i-th input (j-th output) of layer L is alive – not zeroed out.
 
 And ... the method works!
 
-![](/deep-learning/images/morphNet/sc10.png)   
-![](/deep-learning/images/morphNet/sc11.png)   
-![](/deep-learning/images/morphNet/sc12.png)   
+![](/article/images/morphNet/sc10.png)   
+![](/article/images/morphNet/sc11.png)   
+![](/article/images/morphNet/sc12.png)   
 

--- a/article/_posts/2018-10-05-binarized-neural-networks.md
+++ b/article/_posts/2018-10-05-binarized-neural-networks.md
@@ -49,7 +49,7 @@ Instead, a straight-through estimator is used, which corresponds to computing th
 
 - For better efficiency, Shift-based BatchNorm is used, which is an approximation of BatchNorm that uses almost no multiplications.
 
-![](/deep-learning/images/binarized-neural-networks/algorithm3.png)
+![](/article/images/binarized-neural-networks/algorithm3.png)
 
 ## Experiments
 
@@ -57,14 +57,14 @@ Instead, a straight-through estimator is used, which corresponds to computing th
 - CIFAR-10
 - SVHN
 
-> ![](/deep-learning/images/binarized-neural-networks/table1.png)
+> ![](/article/images/binarized-neural-networks/table1.png)
 
 
 **BNNs take longer to train, but are nearly as accurate**:
 
-> ![](/deep-learning/images/binarized-neural-networks/figure1.png)
+> ![](/article/images/binarized-neural-networks/figure1.png)
 
 
 **New binary kernel is 7x faster on GPU**:
 
-> ![](/deep-learning/images/binarized-neural-networks/figure2.png)
+> ![](/article/images/binarized-neural-networks/figure2.png)

--- a/article/_posts/2018-11-08-dmri-connectivity-det-vs-prob.md
+++ b/article/_posts/2018-11-08-dmri-connectivity-det-vs-prob.md
@@ -26,29 +26,29 @@ The goal of the paper is to study which family of tractography algorithms is bes
 
 > Probabilistic tractography samples from the fODF restrained to an aperture cone aligned to the previous direction
 
-> ![](/deep-learning/images/dmri-connectivity/odfs.png)
+> ![](/article/images/dmri-connectivity/odfs.png)
 
 
 ## Experiments
 
 The authors used simulated phantoms (artificial "white matter" configurations) to compare deterministic and probabilistic tractography.
 
-> ![](/deep-learning/images/dmri-connectivity/figure1.png)
+> ![](/article/images/dmri-connectivity/figure1.png)
 
 ## Results
 
 Deterministic is better because it produces fewer false positives. Probabilistic algorithms would be better suited for tractometry or other single-bundle analysis.
 Thresholding streamlines to remove the "bundles" with the lowest number of connections helps, but the threshold needs to be tuned, and the ideal value varies a lot depending on the algorithm used or the connectivity of the phantom...
 
-> ![](/deep-learning/images/dmri-connectivity/figure4.png)
+> ![](/article/images/dmri-connectivity/figure4.png)
 
 
-> ![](/deep-learning/images/dmri-connectivity/figure5.png)
-> ![](/deep-learning/images/dmri-connectivity/figure5-6-legend.png)
+> ![](/article/images/dmri-connectivity/figure5.png)
+> ![](/article/images/dmri-connectivity/figure5-6-legend.png)
 
-> ![](/deep-learning/images/dmri-connectivity/figure6.png)
+> ![](/article/images/dmri-connectivity/figure6.png)
 
 
-> ![](/deep-learning/images/dmri-connectivity/table2.png)
+> ![](/article/images/dmri-connectivity/table2.png)
 
-> ![](/deep-learning/images/dmri-connectivity/figure8.png)
+> ![](/article/images/dmri-connectivity/figure8.png)

--- a/article/_posts/2018-11-23-bar.md
+++ b/article/_posts/2018-11-23-bar.md
@@ -66,7 +66,7 @@ The complete loss function is the sum of a data term and the sparsity loss term 
 
 By pruning feature maps in residual blocks, atypical connectivity emerges:
 
-![](/pruning-acceleration/images/bar/fig4.png){: width="49%"} ![](/article/images/bar/fig4-cap.png){: width="49%"}
+![](/article/images/bar/fig4.png){: width="49%"} ![](/article/images/bar/fig4-cap.png){: width="49%"}
 
 These connectivity patterns generally do not provide computational savings, unless they are leveraged by a special Mixed-Connectivity block implementation (given in the paper).
 

--- a/article/_posts/2018-11-29-concrete.md
+++ b/article/_posts/2018-11-29-concrete.md
@@ -18,7 +18,7 @@ This is useful for learning the shape of a discrete distribution. The binary cas
 
 Consider $$\mathrm{Discrete}(\alpha)$$, a discrete distribution with unnormalized parameters $$\alpha_k \in (0,\infty)$$, where the probability of outcome $$k$$ is $$\alpha_k / \sum_i \alpha_i$$. The sampling from this distribution can be formulated with the Gumbel-Max trick, as seen in Figure&nbsp;1(a). Note that the discrete values are encoded in a **one-hot vector**, and that $$G_i$$ are samples from the standard Gumbel distribution.
 
-![](/machine-learning/images/concrete/fig1.png)
+![](/article/images/concrete/fig1.png)
 
 Note that instead of optimizing $$\alpha$$ directly, we would optimize $$\log \alpha \in \mathbb{R}$$. This allows to avoid constraining the parameters of the network.
 

--- a/article/_posts/2019-05-02-GeoSay.md
+++ b/article/_posts/2019-05-02-GeoSay.md
@@ -51,7 +51,7 @@ Such distributions can help us to distinguish junctions around buildings from ot
 Given an image, all detected junctions *J* can be divided into two subsets,i.e., $$J=J_{B}\cup J_{\bar{B}}$$, where $$J_{B}$$ mean inside the buildings and $$J_{\bar{B}}$$ outside the buildings.
 For a junction *j* with its parametric description $$\theta_{j}=\{c, \vec{\nu}_{1}, \vec{\nu}_{2}, \beta, \rho\}$$, the posterior probability $$P(j\in J_{B}|\theta_{j})$$, measuring the possibility of the event that ajunction *j* is inside buildings, can be derived by
 
-![](/deep-learning/images/GeoSay/eq7.png)
+![](/article/images/GeoSay/eq7.png)
 
 Where the prior probabilities $$P(J_{B})$$, $$P(J_{\bar{B}})$$ and the likelihoods $$P(\theta_{j}\|J_{B})$$, $$P(\theta_{j}\|J_{\bar{B}})$$ can be estimated from a given dataset of buildings, e.g. the Spacenet65 dataset, based on the fitted GMM model.
 


### PR DESCRIPTION
Fix cross-references that were left left-behind.

It looks like we left behind a handful of cross-references in #359, e.g.
https://raw.githubusercontent.com/vitalab/vitalab.github.io/master/article/_posts/2018-09-14-morphnet.md

Honestly, I ignore why.

Executing the `./utils/check_cross_ref_images.sh` script again and providing
the list of all review Markdown files fixes them.