### PR TITLE
Fix for "Emergent Tool Use from Multi-Agent Interaction"

### DIFF
--- a/_data/tags.yml
+++ b/_data/tags.yml
@@ -46,6 +46,7 @@ tags:
 - medical
 - motion-detection
 - MRI
+- multi-agent
 - multiple-sclerosis
 - multi-task
 - multi-task-learning

--- a/article/_posts/2019-09-18-Emergent_Tool_From_MultiAgent_Autocurricula.md
+++ b/article/_posts/2019-09-18-Emergent_Tool_From_MultiAgent_Autocurricula.md
@@ -1,13 +1,13 @@
 ---
 layout: review
 title: "Emergent Tool Use from Multi-Agent Interaction"
-tags:
+tags: reinforcement multi-agent
 author: "Antoine Théberge"
 cite:
     authors: "Bowen Baker, Ingmar Kanitscheider, Todor Markov, Yi Wu, Glenn Powell, Bob McGrew, Igor Mordatch"
     title:   "Emergent Tool Use from Multi-Agent Interaction"
     venue:   "OpenAI Blog"
-pdf: "http://127.0.0.1:4000/article/2019/09/18/Emergent_Tool_From_MultiAgent_Autocurricula.html"
+pdf: "https://d4mucfpksywv.cloudfront.net/emergent-tool-use/paper/Multi_Agent_Emergence_2019.pdf"
 ---
 
 


### PR DESCRIPTION
Merged too fast after getting two reviews
- Added missing tags
- Fixed PDF link