### PR TITLE
Fixed previous reviews typos and improved KaTeX formatting commands

### DIFF
--- a/article/_posts/2019-09-05-Post-DAE.md
+++ b/article/_posts/2019-09-05-Post-DAE.md
@@ -64,4 +64,4 @@ is a "classic fully-connected CRF", but no further detail of its implementation 
 The authors admit themselves that "one of the limitations of Post-DAE is related to data regularity". High variability
 still amounts to somehow uniform segmentations masks in terms of shape and topology, even in pathological cases. The
 authors mention that "cases like brain lesions or tumors where shape is not that regular" are out of the scope of the
-paper, but "will be explored as future work", along with "multiclass and volumetric segmentation cases"...
+paper, but "will be explored as future work", along with "multiclass and volumetric segmentation cases".

--- a/article/_posts/2019-10-15-multi-view-shape-priors.md
+++ b/article/_posts/2019-10-15-multi-view-shape-priors.md
@@ -30,11 +30,11 @@ A number of methods already improve the robustness of cardiac segmentations, but
 Given a source view $$X_i$$, the network learns the low-dimensional representation $$z_i$$ of $$X_i$$ that best
 reconstructs all the $$j$$ target views segmentations $$Y_j$$.
 
-The authors use four source views $$X_i$$ ($$i = 1, ..., 4$$) which are three long axis (LA) images - the two-chamber
+The authors use four source views $$X_i$$ ($$i = 1, \dots, 4$$) which are three long axis (LA) images - the two-chamber
 view (LA1), three-chamber view (LA2), the four-chamber view (LA3) - and one mid-ventricular slice (Mid-V) from the
 short axis (SA) view.
 
-The target segmentations views $$Y_j$$ ($$j = 1, ..., 6$$) correspond to the four previous views plus two SA slices:
+The target segmentations views $$Y_j$$ ($$j = 1, \dots, 6$$) correspond to the four previous views plus two SA slices:
 the apical one and the basal one.
 
 The Shape MAE architecture is detailed in Figure 1.
@@ -46,8 +46,8 @@ The global loss for training the Shape MAE is shown in equation 1.
 ![](/article/images/MultiViewShapePriors/equation1.png)
 
 where:
-- $$L_intra$$ denotes the segmentation loss when the source view $$X_i$$ and the target view $$Y_j$$
-- $$L_inter$$ denotes the loss when two views differ in the number of filters at each level by four times to account
+- $$L_{intra}$$ denotes the segmentation loss when the source view $$X_i$$ and the target view $$Y_j$$
+- $$L_{inter}$$ denotes the loss when two views differ in the number of filters at each level by four times to account
   for the fact that cardiac segmentation is simpler than the lesion segmentation
 - $$\alpha$$ and $$\beta$$ are not both set to 1! $$\alpha$$ was empirically set to 0.5 and $$\beta$$ to 0.001.
 

--- a/article/_posts/2019-10-16-PickAndLearn.md
+++ b/article/_posts/2019-10-16-PickAndLearn.md
@@ -55,7 +55,7 @@ training process, the relative weight of this sample can be too small or too big
 To counter this, the authors add an extra restriction between the quality awareness module and the softmax layer. They
 simply use a weighted hyperbolic tangent (as shown in the equation below), to limit the relative ratio of the output
 quality score from ($$-\infty$$, $$\infty$$) to ($$-\lambda $$, $$\lambda$$). The authors state they empirically
-set $$\lambda$$to be 2.
+set $$\lambda$$ to be 2.
 
 ![](/article/images/PickAndLearn/equation2.png)
 

--- a/article/_posts/2019-10-17-StraightToThePoint.md
+++ b/article/_posts/2019-10-17-StraightToThePoint.md
@@ -61,7 +61,7 @@ The objective function used to update the parameters is the following equation:
 
 ## Supervised policy learning
 Each image acquired in each bin was labelled with one action, which would be the optimal action to perform in that
-state if we relied only on the Manhattan distance $$\mid x - x_goal \mid$$.
+state if we relied only on the Manhattan distance $$\mid x - x_{goal} \mid$$.
 
 The authors train a classifier with the same architecture shown in Figure 4, with the only exception that the last
 layer is followed by a soft-max activation function.
@@ -76,7 +76,7 @@ layer is followed by a soft-max activation function.
 The authors explain the intuition behind the better results for the DQN approach compared to the supervised policy.
 They state that RL is able to avoid and go around areas that are highly ambiguous as the Q-Values in correspondence of
 the actions leading to those states should not be very high. They also hypothesize that RL implicitly learns the
-spatial arrangement of the different pictures on the chest, since it must be able to differientate between them to
+spatial arrangement of the different pictures on the chest, since it must be able to differentiate between them to
 produce different ranges of Q-values (low when far away, and higher near the goal).
 
 

--- a/article/_posts/2020-01-17-PHiSeg.md
+++ b/article/_posts/2020-01-17-PHiSeg.md
@@ -21,17 +21,12 @@ pdf: "https://arxiv.org/pdf/1906.04045.pdf"
 # Introduction
 
 Medical segmentation problems are often characterized by ambiguities due to inherent uncertainties such as:
-
 - Restrictions imposed by the image acquisition (e.g. poor contrast)
-
 - Variations in annotation “styles” between different experts
 
 To account for uncertainty, different methods have already been proposed, but they all have downsides:
-
 - Bayesian networks: samples may vary pixel by pixel and miss complex correlation structures
-
 - Ensemble networks: fixed number of hypotheses
-
 - Probabilistic U-Net: samples with limited diversity
 
 The proposed method is inspired by Laplacian Pyramids, generating segmentation samples at low-resolution and
@@ -55,7 +50,7 @@ The methods' main loss is detailed in equation 2:
 
 ![](/article/images/PHiSeg/equation2.jpg)
 
-The prior and posterior distributions are parameterized as axis aligned normal distributions $$N(z \mid \mu, \sigma)$$,
+The prior and posterior distributions are parameterized as axis aligned normal distributions $$N(z|\mu, \sigma)$$,
 like detailed in equations 3 and 4:
 
 ![](/article/images/PHiSeg/equations3_4.jpg)
@@ -64,7 +59,7 @@ To ensure stable training, the authors mentions that they need to deviate from t
 
 1. The magnitude of the KL terms depends on the dimensionality of $$z$$. However, since the dimensionality of $$z$$
    grows with $$O(2^l)$$, this led to optimization problems. To counteract this, the authors heuristically set the
-   weights $$\alpha = 2^{l-1} in Eq. 2.
+   weights $$\alpha = 2^{l-1}$$ in Eq. 2.
 2. To  enforce the desired behavior that $$z_l$$ should only model the data at its corresponding resolution, a
    reconstruction loss was added to the upsampled output of each level: $$CE(ups(\hat{s}_{l}), s_{gt})$$ for $$l \gt 1$$
 
@@ -82,7 +77,6 @@ Two experiments were designed to evaluate the method.
 
 1. Assess how closely the distribution of generated samples matched the distribution of ground-truth annotations by
 training the methods using the masks from all available annotators
-
 2. Investigate the models’ ability to infer the inherent uncertainties (train using only one of the annotations, and
 test on all available annotations)
 

--- a/article/_posts/2020-02-13-CSVAE.md
+++ b/article/_posts/2020-02-13-CSVAE.md
@@ -21,7 +21,7 @@ pdf: "https://arxiv.org/pdf/1812.06190.pdf"
 The closest previous work that attempted to remove information correlated with the conditioned label is Conditional VAE
 with Information Factorization (CondVAE-*info*), whose objective function is given below:
 
-$$\max_\phi \min_\psi L(r_\psi(q_\phi(z \mid x)), y)$$
+$$\max_\phi \min_\psi L(r_\psi(q_\phi(z|x)), y)$$
 
 where $$r_{\psi}(z)$$ is an additional network trained to predict $$y$$ from $$z$$. However, the authors claim that the
 fact that the decoder relies on the one-dimensional variable $$y$$ to reconstruct the data is suboptimal, hence the
@@ -42,7 +42,7 @@ The detailed explanation of the objective functions is quite long, and should be
 understand the role of each variable (and the notation used later on) suffice to say that this is how the authors
 decompose the joint-likelihood:
 
-$$ \log p_{\theta,\gamma}(x,y,w,z) = \log p_\theta(x \mid w,z) + \log p(z) + \log p_\gamma(w \mid y) + \log p(y)$$
+$$ \log p_{\theta,\gamma}(x,y,w,z) = \log p_\theta(x|w,z) + \log p(z) + \log p_\gamma(w|y) + \log p(y)$$
 
 An example of what the method can achieve on the swiss roll is shown in Figure 2.
 
@@ -54,11 +54,11 @@ distinct encoders for each:
 - label, in case of binary label, or
 - label value, in case of multi-label that should be one-hot encoded (like the TFD referenced later).
 
-For arbitrary fixed choices $$\mu_1,\sigma_1,\mu_2,\sigma_2$$, for each $$i=1,...,k$$ the authors state:
+For arbitrary fixed choices $$\mu_1,\sigma_1,\mu_2,\sigma_2$$, for each $$i=1,\dots,k$$ the authors state:
 
-$$ p(w_i \mid y_i=1) = \mathcal{N}(\mu_1,\sigma_1)$$
+$$ p(w_i|y_i=1) = \mathcal{N}(\mu_1,\sigma_1)$$
 
-$$ p(w_i \mid y_i=0) = \mathcal{N}(\mu_2,\sigma_2)$$
+$$ p(w_i|y_i=0) = \mathcal{N}(\mu_2,\sigma_2)$$
 
 The authors also mention that they always chose $$W_i=\mathbb{R}_2$$ for all $$i$$. The choice is arbitrary, but it
 helps when visualizing the distribution of the data in the latent subspace.
@@ -68,14 +68,14 @@ The authors define an attribute switching function $$G_{i,j}$$ to change the lab
 
 As reference, we could define $$G_{i,j}$$ in the following manner for a traditional VAE:
 
-For each $$i = 1,...,k$$ let $$S_i$$ be the set of $$(x,y) \in D$$ with $$y_i=1$$. Let $$m_i$$ be the mean of the
+For each $$i = 1,\dots,k$$ let $$S_i$$ be the set of $$(x,y) \in D$$ with $$y_i=1$$. Let $$m_i$$ be the mean of the
 elements of $$S_i$$ encoded in the latent space, that is $$\mathbb{E}_{S_i}[\mu_\phi(x)]$$. We can define:
 
 $$G_{i,j}(x) = \mu_\theta(\mu_\phi(x) - m_i + m_j)$$
 
 For the CSVAE, the definition of $$G_{i,j}$$ is now as follows:
 
-Let $$p = (p_1,..., p_k) \in \prod_{i=1}^k W_i$$ be any vector with $$p_l = \vec{0}$$ for $$l \neq j$$.
+Let $$p = (p_1,\dots, p_k) \in \prod_{i=1}^k W_i$$ be any vector with $$p_l = \vec{0}$$ for $$l \neq j$$.
 For $$(x,y) \in D$$ we can define:
 
 $$G_{i,j}(x,p) = \mu_\theta(\mu_{\phi_1}(x), p)$$

--- a/article/_posts/2020-08-13-DisentanglingByFactorising.md
+++ b/article/_posts/2020-08-13-DisentanglingByFactorising.md
@@ -23,7 +23,7 @@ The authors analyze the disentanglement and reconstruction aspects of $$\beta$$-
 the KL divergence term in the classic VAE loss. The $$\beta$$-VAE objective can be formulated like follows, where $$\beta \geq 1$$:
 
 $$
-\frac{1}{N} \sum_{i=1}^{N} [\mathbb{E}_{q(z|x^{(i)})}[\log p(x^{(i)}|z)] - \beta KL(q(z|x^{(i)})~\|~p(z))]
+\frac{1}{N} \sum_{i=1}^{N} \Big[\mathbb{E}_{q(z|x^{(i)})}[\log p(x^{(i)}|z)] - \beta KL(q(z|x^{(i)})~\|~p(z))\Big]
 $$
 
 The first term is the reconstruction error, and the second term is the complexity penalty. This second term can be
@@ -47,7 +47,7 @@ Given the claim about the mutual information term, the authors propose to motiva
 directly encourages the independence in the code distribution:
 
 $$
-\frac{1}{N} \sum_{i=1}^{N} [\mathbb{E}_{q(z|x^{(i)})}[\log p(x^{(i)}|z)] - KL(q(z|x^{(i)})~\|~p(z))] 
+\frac{1}{N} \sum_{i=1}^{N} \Big[\mathbb{E}_{q(z|x^{(i)})}[\log p(x^{(i)}|z)] - KL(q(z|x^{(i)})~\|~p(z))\Big] 
 - \gamma KL(q(z)~\|~\bar{q}(z))
 $$
 
@@ -61,7 +61,8 @@ the KL divergence. The *density-ratio trick* consists of training a discriminato
 estimate whether a sample comes from $$q(z)$$ or $$\bar{q}(z)$$. This allows them to rephrase the TC as:
 
 $$
-TC(z) = KL(q(z)~\|~\bar{q}(z)) = \mathbb{E}_{q(z)}[\log \frac{q(Z)}{\bar{q}(z)}] \approx \mathbb{E}_{q(z)}[\log \frac{D(z)}{1 - D(z)}]
+TC(z) = KL(q(z)~\|~\bar{q}(z)) = \mathbb{E}_{q(z)}\Bigg[\log \frac{q(Z)}{\bar{q}(z)}\Bigg] 
+\approx \mathbb{E}_{q(z)}\Bigg[\log \frac{D(z)}{1 - D(z)}\Bigg]
 $$
 
 The discriminator and VAE are trained jointly, and the training algorithm for FactorVAE is given below:


### PR DESCRIPTION
Given the issues with the math rendering this weekend, I took a look back at my old reviews to see if anything was amiss. This made me notice some typos/formatting that could be improved. This PR addresses those issues. I also took advantage of some of the options the new math formatting (which support more fonts) to improve some equations' layout.

NOTE: Those issues are NOT related to the new math formatting. They were there to begin with (passed my own inspection and the review process).