### PR TITLE
FIX: Change ruby version in how-to

### DIFF
--- a/how-to-install-ruby.md
+++ b/how-to-install-ruby.md
@@ -33,8 +33,8 @@ source ~/.bashrc
 
 ## Install Ruby
 ~~~
-rbenv install -v 2.4.0
-rbenv global 2.4.0
+rbenv install -v 2.7.1
+rbenv global 2.7.1
 ~~~
 Make sure you have the right version installed and selected :
 

--- a/how-to.md
+++ b/how-to.md
@@ -130,7 +130,7 @@ If that does not resolve your problem, you may have a tooling version mismatch. 
 
 ### Running `bundle install` has modified `Gemfile.lock`
 
-This is likely happening because you don't have Ruby 2.6.2. Confirm by running `git diff`. If you see something like this:
+This is likely happening because you don't have Ruby 2.7.1. Confirm by running `git diff`. If you see something like this:
 
 ```
  RUBY VERSION


### PR DESCRIPTION
Self-explanatory. I `git-grep`ed and this is the last reference to `2.4.0`

(500th PR whoo !)