### PR TITLE
ENH: Fix typos/improve wording in sigma-VAE paper review

### DIFF
--- a/article/_posts/2021-07-09-SigmaVAE.md
+++ b/article/_posts/2021-07-09-SigmaVAE.md
@@ -13,7 +13,7 @@ pdf: "https://arxiv.org/pdf/2006.13202.pdf"
 
 # Highlights
 
-- Their contributions are:
+Contributions:
  - A careful choice of the decoder distribution in VAEs to improve the
 performance of naïve calibrated decoders, removing the need to tune the
 distortion vs. rate (i.e. the information between the prior and the posterior)
@@ -63,8 +63,8 @@ naïve MSE loss assumes a constant variance, it does not effectively represent
 the uncertainty of the prediction. Thus common VAEs using the MSE reconstruction
 loss are poorly calibrated.
 
-Authors propose to learn the variance (i.e. calibrate the decoder) a better
-performance might be achieved. 
+Authors propose to learn the variance (i.e. calibrate the decoder) to achieve
+a better performance.
 
 
 # Methods
@@ -94,7 +94,7 @@ from the training data as:
 
 ![](/article/images/sigmaVAE/sigma.jpg)
 
-Finally authors propose to learn on a per-image $$\sigma$$ 
+Finally authors propose to learn $$\sigma$$ on a per-image basis.
 
 Optimal $$\sigma$$-VAE uses a single variance value shared across all data
 points. However, their $$\sigma$$-VAE formulation also allows to learn a


### PR DESCRIPTION
Fix typos/improve wording in sigma-VAE paper review.