### PR TITLE
Allow letting page.cite.title blank

### DIFF
--- a/_layouts/review.html
+++ b/_layouts/review.html
@@ -50,7 +50,7 @@ layout: default
     </p>
     {% if page.cite %}
       <p class="post-meta">
-        <strong>Reference</strong> : {{ page.cite.authors }}. <em>{{ page.cite.title }}.</em> {{ page.cite.venue }}.
+        <strong>Reference</strong> : {{ page.cite.authors }}. <em>{{ page.cite.title | default: page.title }}.</em> {{ page.cite.venue }}.
       </p>
     {% endif %}
   </header>

--- a/templates/review_template.md
+++ b/templates/review_template.md
@@ -15,6 +15,8 @@ pdf: ""
 
 Something[^1]
 
+![](/article/images/NGU/ngu.jpeg)
+
 # Introduction
 
 


### PR DESCRIPTION
Instead of putting the same title twice