### PR TITLE
Add `.ruby-version` to `.gitignore` to allow per-project config of rbenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _previews
 .jekyll-cache
 .Rhistory
 *.swp
+.ruby-version


### PR DESCRIPTION
This is useful for people with multiple ruby versions and environments on the same machine.