### PR TITLE
Remove unused KaTeX auto-render extension

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,15 +11,6 @@
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title | escape }}" href="{{ "/feed.xml" | relative_url }}">
 
-	<!-- KaTeX stuff -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css" integrity="sha384-AfEj0r4/OFrOo5t7NnNe46zW/tFgW6x/bCJG8FqQCEo3+Aro6EYUG4+cU+KJWu/X" crossorigin="anonymous">
-
-  <!-- The loading of KaTeX is deferred to speed up page rendering -->
-  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.js" integrity="sha384-g7c+Jr9ZivxKLnZTDUhnkOnsh30B4H0rpLUpJ4jAIKs4fnJI+sEnkvrMWph2EDg4" crossorigin="anonymous"></script>
-
-  <!-- To automatically render math in text elements, include the auto-render extension: -->
-  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/contrib/auto-render.min.js" integrity="sha384-mll67QQFJfxn0IYznZYonOWZ644AWYC+Pt2cHqMaRhXVrursRwvLnLaebdGIlYNa" crossorigin="anonymous"
-        onload="renderMathInElement(document.body);"></script> 
   {% if jekyll.environment == 'production' and site.google_analytics %}
   {% include google-analytics.html %}
   {% endif %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="{{ "/assets/custom.css" | relative_url }}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title | escape }}" href="{{ "/feed.xml" | relative_url }}">
+  <script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
 
   {% if jekyll.environment == 'production' and site.google_analytics %}
   {% include google-analytics.html %}

--- a/_layouts/review.html
+++ b/_layouts/review.html
@@ -59,15 +59,3 @@ layout: default
     {{ content }}
   </div>
 </article>
-
-<script>
-  $("script[type='math/tex']").replaceWith(function() {
-      var tex = $(this).text();
-      return katex.renderToString(tex, {displayMode: false});
-  });
-
-  $("script[type='math/tex; mode=display']").replaceWith(function() {
-      var tex = $(this).html();
-      return katex.renderToString(tex.replace(/%.*/g, ''), {displayMode: true});
-  });
-</script>


### PR DESCRIPTION
The KaTeX extension is no longer used because it seems (according to the [_config.yaml](https://github.com/vitalab/vitalab.github.io/blob/master/_config.yml#L26)) that the ["fix" to KaTeX](https://github.com/vitalab/vitalab.github.io/pull/494) did not fix KaTeX, but rather switched to using MathJax.

I stumbled upon this because I had trouble rendering some LaTeX (_\argmax_ operator) that KaTeX apparently supports. I discovered that the problem was not with KaTeX, but rather that we're **not** using KaTeX, but rather MathJax, which does not seem to support _\argmax_ / _\argmin_.

I have no problem with sticking to MathJax now, since we haven't had problems since and from what I could find it supports more LaTeX functions than KaTeX. But I think it's best to get rid of everything related to KaTeX to avoid future contributors the confusion I had today.

@AntoineTheb Since you were the one who made the change originally (and who mostly set-up the CREATIS website which now uses MathJax as well), if there's anything I misunderstood about the config, please tell me!

P.S. What I don't understand is that [apparently we would need a similar extension for MathJax](http://webdocs.cs.ualberta.ca/~zichen2/blog/coding/setup/2019/02/17/how-to-add-mathjax-support-to-jekyll.html) (instead of the one for KaTeX), just like [the CREATIS website has](https://github.com/creatis-myriad/creatis-myriad.github.io/blob/main/_includes/head.html#L5). But even if it's not there everything seems to be working fine? So if you have any theories on how that's possible, I'm all ears :ear: 