### PR TITLE
Switched names and typo correction

### DIFF
--- a/_data/members.yml
+++ b/_data/members.yml
@@ -22,8 +22,8 @@ professors:
 
 current_members:
 
-  - firstname: 'David'
-    lastname: 'Yoan'
+  - firstname: 'Yoan'
+    lastname: 'David'
     picture: 'ydavid.jpg'
     interests: "Deep learning, graph neural network, harmonization, diffusion MRI"
     grades:
@@ -31,17 +31,16 @@ current_members:
         name: Intern
         startyear: 2024
         endyear: 2025
-
       - grade:
         name: PhD
         startyear: 2025
         endyear: ''
 
 
-  - firstname: 'Lévesque'
-    lastname: 'Jeremi'
+  - firstname: 'Jeremi'
+    lastname: 'Levesque'
     picture: 'jlevesque.jpg'
-    interests: "Deep learning, reinforcement learning, white matter imageing, diffusion MRI"
+    interests: "Deep learning, reinforcement learning, white matter imaging, diffusion MRI"
     grades:
       - grade:
         name: MSc


### PR DESCRIPTION
Just swapped names to be consistent with the rest of the list and fixed a typo on "imaging".